### PR TITLE
Fix appcast.xml and Sparkle?

### DIFF
--- a/_includes/appcast.inc
+++ b/_includes/appcast.inc
@@ -5,7 +5,7 @@
         <description>Most recent changes with links to updates.</description>
         <language>en</language>
         {% for release in site.github.releases %}
-            {% if release.prerelease and page.prereleases %}{% break %}{% endif %}
+            {% if release.prerelease and !page.include_prereleases %}{% continue %}{% endif %}
             {% assign tag_name = release.tag_name %}
             {% assign release_prefix = "v/" %}
             {% unless release.tag_name contains release_prefix %}{% continue %}{% endunless %}

--- a/_includes/appcast.inc
+++ b/_includes/appcast.inc
@@ -6,11 +6,19 @@
         <language>en</language>
         {% for release in site.github.releases %}
             {% if release.prerelease and !page.include_prereleases %}{% continue %}{% endif %}
-            {% assign tag_name = release.tag_name %}
+
+            {% comment %}
+            <!--
+                This was all related to the "new" build system referenced in
+                c6891a8e (ca 2018) and seems to want to parse tags like v/0.17.
+            -->
             {% assign release_prefix = "v/" %}
             {% unless release.tag_name contains release_prefix %}{% continue %}{% endunless %}
             {% assign version_nums = release.tag_name | remove_first: release_prefix | split: '/' %}
             {% assign version = version_nums[1] %}
+            {% endcomment %}
+
+            {% assign version = release.tag_name %}
             {% assign short_version = nil %}
 
             {% assign dmg_sign = nil %}

--- a/appcast.xml
+++ b/appcast.xml
@@ -1,4 +1,4 @@
 ---
-prereleases: true
+include_prereleases: false
 ---
 {%include appcast.inc %}


### PR DESCRIPTION
I think that this might fix how the `appcast.xml` file is generated, which might allow Sparkle to start working again.

As with everything GitX, I'm out of my league when it comes to building the app (I'm don't use Xcode or Objective C) or the site (I don't use Jekyll or GH pages), so I'm mostly fumbling in the dark. That said, when the `appcast.xml` file was added, it looks like it was [intended to skip "prerelease" releases](https://github.com/gitx/gitx.github.io/commit/a020c2d51265dffc4d4e012db52cd6de418bfd7a#diff-b850b311bc51c1ba5473b71055d5941fb852ce334a1574a728b3229cdc2045fcR8-R9), but when it was updated shortly afterward, it looks like [it changed to just stop rendering any releases if it encountered a prerelease](https://github.com/gitx/gitx.github.io/commit/c6891a8e044d4df15358d743d5f49c4c99b2b568#diff-b850b311bc51c1ba5473b71055d5941fb852ce334a1574a728b3229cdc2045fcR8). I believe that [other parts of the `appcast.inc` template were meant to handle/parse releases that were tagged like `v/0.17`](https://github.com/gitx/gitx.github.io/commit/c6891a8e044d4df15358d743d5f49c4c99b2b568#diff-b850b311bc51c1ba5473b71055d5941fb852ce334a1574a728b3229cdc2045fcR9-R13) or something like that, vs the simpler `0.17`, `0.18`, etc in use currently.

### What this changes:
- changes the name of the `prereleases` front matter variable to better reflect what it's (I think) intended to do
- changes a usage of `break` to `continue` (ie skip this prerelease vs stop rendering any releases if we encoutner a prerelease)
- comments/skips any sort of tag parsing and just uses the tag name as the the version

I *do not* know how to test this; I'm just reading the code and making some educated guesses. FWIW, I did look at the output of `curl https://api.github.com/repos/gitx/gitx/releases` to see what the GH releases API output looks like. Based on that, I have reason to think that this might work, but it also might take some more iterations.

@tiennou any input you have on this would be appreciated.

@hannesa2 I wonder if this might close https://github.com/gitx/gitx/issues/279