### PR TITLE
explicitly tell jekyll which project to fetch releases from

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,3 +4,6 @@ description: "an open source Git GUI for Mac OS X"
 baseurl: ""
 markdown: kramdown
 permalink: pretty
+
+# Which project should {{ site.github.* }} refer to?
+repository: gitx/gitx

--- a/_includes/appcast.inc
+++ b/_includes/appcast.inc
@@ -5,29 +5,11 @@
         <description>Most recent changes with links to updates.</description>
         <language>en</language>
         {% for release in site.github.releases %}
-            {% if release.prerelease and !page.include_prereleases %}{% continue %}{% endif %}
-
-            {% comment %}
-            <!--
-                This was all related to the "new" build system referenced in
-                c6891a8e (ca 2018) and seems to want to parse tags like v/0.17.
-            -->
-            {% assign release_prefix = "v/" %}
-            {% unless release.tag_name contains release_prefix %}{% continue %}{% endunless %}
-            {% assign version_nums = release.tag_name | remove_first: release_prefix | split: '/' %}
-            {% assign version = version_nums[1] %}
-            {% endcomment %}
+            {% if release.prerelease and page.include_prereleases != true %}{% continue %}{% endif %}
 
             {% assign version = release.tag_name %}
             {% assign short_version = nil %}
 
-            {% assign dmg_sign = nil %}
-            {% assign body_lines = release.body | newline_to_br | split: '<br />' %}
-            {% for line in body_lines %}
-                {% if line contains "DMG Signature: " %}
-                    {% assign dmg_sign = line | remove_first: "DMG Signature: " | strip %}
-                {% endif %}
-            {% endfor %}
             {% for asset in release.assets %}
                 {% assign asset_ext = asset.browser_download_url | slice: -3, 3 %}
                 {% if asset_ext != "dmg" %}{% break %}{% endif %}
@@ -45,7 +27,6 @@
                     {% if short_version %}sparkle:shortVersionString="{{ short_version }}"{% endif %}
                     length="{{ asset_size }}"
                     type="application/octet-stream"
-                    {% if dmg_sign %}sparkle:dsaSignature="{{ dmg_sign }}"{% endif %}
                 />
             </item>
             {% endif %}

--- a/gitx/appcast.xml
+++ b/gitx/appcast.xml
@@ -1,0 +1,4 @@
+---
+include_prereleases: false
+---
+{%include appcast.inc %}


### PR DESCRIPTION
Thanks @hannesa2. This might get us closer. 

This PR ...
- configures the `github-metadata` plugin to look at the `gitx/gitx` project via the new line in `_config.yml`, which means that the appcast will include data for the gitx project, not the `gitx.github.io` project. 
- fixes a logical issue that was causing preleases to be included in the appcast.
- includes a copy of the `appcast.xml` in the gitx subdir b/c that's where gitx/sparkle is actually looking: https://github.com/gitx/gitx/blob/master/Resources/Info.plist#L97

I *have* tested this w/ Jekyll locally and the appcast does include the correct release information. I *have not* tested this w/ Sparkle, though. Doing so locally requires a fake https certificate or something about "secure app transport" that I don't understand. At this time, I'm wonder if the issue is not w/ Sparkle but instead just w/ our appcast. If we can get the appcast to build correctly, then we can work on fixing sparkle if it indicates further issues.

### Background

Jekyll sites on GH pages apparently include https://github.com/jekyll/github-metadata by default, allowing them to fetch project metadata. This is how `appcast.xml/appcast.inc` are able to use `{{ site.github.project_title }}` etc. Note though that the existing [`appcast.xml`](https://gitx.github.io/appcast.xml) includes no releases and also says that the "project title" is "gitx.github.io". This now makes sense since it's literally running in the `gitx.github.io` project, but it's clearly intended to refer to `gitx/gitx`.

